### PR TITLE
Sorted YAML output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "http://rubygems.org"
 
 gem "naether", "~> 0.9.0"
 gem "thor",     "~> 0.14.6"
+gem "i18n_yaml_sorter", "~> 0.2.0"
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
@@ -9,6 +10,6 @@ group :development do
   gem "rspec", "~> 2.9.0"
   gem "jeweler", "~> 1.8.4"
   gem "yard", "~> 0.8.0"
-  gem 'solr_sail', '~>0.0.6'
+  gem 'solr_sail', '~>0.0.6',   :platforms => :jruby
   gem 'jruby-openssl',   :platforms => :jruby
 end

--- a/lib/lock_jar/runtime.rb
+++ b/lib/lock_jar/runtime.rb
@@ -15,6 +15,8 @@
 
 require 'rubygems'
 require "yaml"
+require 'stringio'
+require 'i18n_yaml_sorter'
 require 'singleton'
 require 'lock_jar/resolver'
 require 'lock_jar/dsl'
@@ -151,9 +153,9 @@ module LockJar
               'resolved_dependencies' => resolved_notations.sort } 
           end
         end
-    
+
         File.open( opts[:lockfile] || "Jarfile.lock", "w") do |f|
-          f.write( lock_data.to_yaml )
+          f.write( I18nYamlSorter::Sorter.new(StringIO.new(lock_data.to_yaml)).sort )
         end
         
         lock_data


### PR DESCRIPTION
Small patch to sort the YAML output in Jarfile.lock. Having all the keys & jar entries sorted makes it much easier to diff when making changes and to compare against older revisions. 
