### PR TITLE
Use local_repository from lockfile in install()

### DIFF
--- a/lib/lock_jar/runtime.rb
+++ b/lib/lock_jar/runtime.rb
@@ -61,6 +61,10 @@ module LockJar
       deps = list( jarfile_lock, groups, {:with_locals => false}.merge( opts ), &blk )
       
       lockfile = LockJar::Domain::Lockfile.read( jarfile_lock )
+      if opts[:local_repo].nil? && lockfile.local_repository
+        opts[:local_repo] = lockfile.local_repository
+      end
+
       lockfile.remote_repositories.each do |repo|
           resolver(opts).add_remote_repository( repo )
       end


### PR DESCRIPTION
This fixes an issue where `lockjar install` was ignoring the local_repository set in the lockfile. That basically meant that it installed into the default repo location (usually ~/.m2/repository). However, a subsequent LockJar.load() would try to read from local_repo, and (if different from the default repo) not find the Jars.

This should also fix https://github.com/mguymon/lock_jar/issues/15 - I actually noticed this while trying to get my project to build under Travis-CI.
