### PR TITLE
Register multiple Jarfiles to merge and lock as a unit

### DIFF
--- a/lib/lock_jar.rb
+++ b/lib/lock_jar.rb
@@ -106,8 +106,15 @@ module LockJar
   # @return [Array] All registered jarfiles
   def self.register_jarfile( jarfile )
     fail "Jarfile not found: #{ jarfile }" unless File.exists? jarfile
+    registered_jarfiles << jarfile
+  end
+
+  def self.reset_registered_jarfiles
+    @@registered_jarfiles = []
+  end
+
+  def self.registered_jarfiles
     @@registered_jarfiles ||= []
-    @@registered_jarfiles << jarfile
   end
 
   # Lock the registered Jarfiles and generate a Jarfile.lock.
@@ -120,7 +127,8 @@ module LockJar
   #
   # @return [Hash] Lock data
   def self.lock_registered_jarfiles( *args, &blk )
-    jarfiles = @@registered_jarfiles || []
+    jarfiles = registered_jarfiles
+    return if jarfiles.empty?
     instances = jarfiles.map do |jarfile|
       LockJar::Domain::JarfileDsl.create jarfile
     end

--- a/spec/fixtures/Jarfile2
+++ b/spec/fixtures/Jarfile2
@@ -1,0 +1,1 @@
+jar "org.eclipse.jetty:jetty-servlet:8.1.3.v20120416"


### PR DESCRIPTION
This allows me to define a library that depends on other libraries that also use lock_jar without needing clients to use any tools to prebuild a Jarfile.lock or manually combine the dependent libraries' Jarfiles beforehand.

Instead, each Jarfile can be registered using LockJar.register_jarfile(jarfile_path). Then all of the registered Jarfiles can be merged by calling LockJar.lock_registered_jarfiles. Finally, LockJar.load can be called as usual.
