### PR TITLE
add option for resolve: false to LockJar.list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,6 @@ Style/PredicateName:
 
 Style/Lambda:
   Enabled: false
+
+Style/Alias:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'pry'
   gem 'yard'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.36.0'
 end

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ methods:
     end
 
     group 'test' do
-      jar 'junit:junit:jar:4.10', :group => 'test'
+      jar 'junit:junit:jar:4.12', :group => 'test'
     end
 
 ### Resolving dependencies
@@ -90,7 +90,7 @@ The _Jarfile.lock_ generated is a YAML file containing information on how to han
         - ch.qos.logback:logback-classic:jar:0.9.24
         - ch.qos.logback:logback-core:jar:0.9.24
         - com.metapossum:metapossum-scanner:jar:1.0
-        - com.slackworks:modelcitizen:jar:0.2.2
+        - com.tobedevoured.modelcitizen:core:jar:0.8.1
         - commons-beanutils:commons-beanutils:jar:1.8.3
         - commons-io:commons-io:jar:1.4
         - commons-lang:commons-lang:jar:2.6
@@ -123,10 +123,10 @@ The _Jarfile.lock_ generated is a YAML file containing information on how to han
             transitive: {}
       test:
         dependencies:
-        - junit:junit:jar:4.10
+        - junit:junit:jar:4.12
         - org.hamcrest:hamcrest-core:jar:1.1
         artifacts:
-        - jar:junit:junit:jar:4.10:
+        - jar:junit:junit:jar:4.12:
             transitive:
               org.hamcrest:hamcrest-core:jar:1.1: {}
     ...
@@ -301,7 +301,7 @@ Sample buildfile with LockJar
     lock_jar do
 
          group 'test' do
-           jar 'junit:junit:jar:4.10'
+           jar 'junit:junit:jar:4.12'
          end
     end
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The _Jarfile.lock_ generated is a YAML file containing information on how to han
 * _[Hash]_ will set the options, e.g. `{ :local_repo => 'path' }`
   * **:local_repo** _[String]_ sets the local repo path. Defaults to `ENV['M2_REPO']` or `'~/.m2/repository'`
   * **:local_paths** _[Boolean]_ converts the notations to paths of jars in the local repo
-  * **:resolve** _[Boolean]_ to true will make transitive dependences resolve before returning list of jars
+  * **:resolve** _[Boolean]_ to `true` will make transitive dependences resolve before returning list of jars. Setting to `false` will list dependencies, excluding transitive dependencies.
 
 **LockJar.load(*args)**: Loads all dependencies to the classpath for groups from the Jarfile.lock. Default group is _default_. Default lock file is _Jarfile.lock_.
 * _[String]_ will set the Jarfile.lock, e.g. `'Better.lock'`
@@ -337,7 +337,7 @@ to allow creation of a _Jarfile.lock_ when Bundler calls `install` and `update`.
     end
 
 You can optionally create a _Jarfile_ that will automatically be included when you `bundle install` or `bundle update`. Otherwise
-Gems with a Jarfile will be merge to generate a _Jarfile.lock_. 
+Gems with a Jarfile will be merge to generate a _Jarfile.lock_.
 
 ### Bundler to LockJar groups
 

--- a/lib/lock_jar.rb
+++ b/lib/lock_jar.rb
@@ -168,37 +168,35 @@ module LockJar
       args = args.reject { |arg| arg.is_a? String }
       lock(combined, *args, &blk)
     end
-  end
 
-  private
-
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-  def self.extract_args(type, args, &blk)
-    lockfile_or_path = nil
-    opts = {}
-    groups = ['default']
-    args.each do |arg|
-      case arg
-      when Hash
-        opts.merge!(arg)
-      when String
-        lockfile_or_path = arg
-      when LockJar::Domain::Lockfile
-        lockfile_or_path = arg if type == :lockfile
-      when LockJar::Domain::Dsl
-        lockfile_or_path = arg if type == :jarfile
-      when Array
-        groups = arg
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def extract_args(type, args, &blk)
+      lockfile_or_path = nil
+      opts = {}
+      groups = ['default']
+      args.each do |arg|
+        case arg
+        when Hash
+          opts.merge!(arg)
+        when String
+          lockfile_or_path = arg
+        when LockJar::Domain::Lockfile
+          lockfile_or_path = arg if type == :lockfile
+        when LockJar::Domain::Dsl
+          lockfile_or_path = arg if type == :jarfile
+        when Array
+          groups = arg
+        end
       end
-    end
-    if blk.nil? && lockfile_or_path.nil?
-      if type == :lockfile
-        lockfile_or_path = opts.fetch(:lockfile, 'Jarfile.lock')
-      elsif type == :jarfile
-        lockfile_or_path = 'Jarfile'
+      if blk.nil? && lockfile_or_path.nil?
+        if type == :lockfile
+          lockfile_or_path = opts.fetch(:lockfile, 'Jarfile.lock')
+        elsif type == :jarfile
+          lockfile_or_path = 'Jarfile'
+        end
       end
+      [lockfile_or_path, groups, opts]
     end
-    [lockfile_or_path, groups, opts]
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/lib/lock_jar/buildr.rb
+++ b/lib/lock_jar/buildr.rb
@@ -22,7 +22,7 @@ module Buildr
 
   class << self
     def project_to_lockfile(project)
-      "#{project.name.gsub(/:/, '-')}.lock"
+      "#{project.name.tr(':', '-')}.lock"
     end
   end
 

--- a/lib/lock_jar/bundler.rb
+++ b/lib/lock_jar/bundler.rb
@@ -23,13 +23,13 @@ module LockJar
         jarfile = File.expand_path(jarfile_opt || 'Jarfile')
 
         # load local Jarfile
-        if File.exist?(jarfile)
-          dsl = LockJar::Domain::JarfileDsl.create(jarfile)
+        dsl = if File.exist?(jarfile)
+                LockJar::Domain::JarfileDsl.create(jarfile)
 
-        # Create new Dsl
-        else
-          dsl = LockJar::Domain::Dsl.new
-        end
+              # Create new Dsl
+              else
+                LockJar::Domain::Dsl.new
+              end
 
         gems_with_jars = []
         ::Bundler.definition.groups.each do |group|

--- a/lib/lock_jar/domain/artifact.rb
+++ b/lib/lock_jar/domain/artifact.rb
@@ -25,11 +25,9 @@ module LockJar
       attr_reader :type
 
       def <=>(other)
-        if other.is_a? Artifact
-          to_urn <=> other.to_urn
-        else
-          to_urn <=> other.to_s
-        end
+        return to_urn <=> other.to_urn if other.is_a? Artifact
+
+        to_urn <=> other.to_s
       end
 
       def resolvable?
@@ -104,11 +102,9 @@ module LockJar
 
       def <=>(other)
         if other.is_a? Pom
-          if to_urn == other.to_urn
-            return Set.new(scopes) <=> Set.new(other.scopes)
-          else
-            to_urn <=> other.to_urn
-          end
+          return Set.new(scopes) <=> Set.new(other.scopes) if to_urn == other.to_urn
+
+          to_urn <=> other.to_urn
         else
           super
         end

--- a/lib/lock_jar/domain/dsl.rb
+++ b/lib/lock_jar/domain/dsl.rb
@@ -21,7 +21,7 @@ module LockJar
   module Domain
     #
     class Dsl
-      DEFAULT_GROUP = ['default']
+      DEFAULT_GROUP = ['default'].freeze
 
       attr_accessor :artifacts, :remote_repositories, :local_repository, :groups,
                     :maps, :excludes, :merged, :clear_repositories

--- a/lib/lock_jar/runtime.rb
+++ b/lib/lock_jar/runtime.rb
@@ -76,7 +76,7 @@ module LockJar
 
       groups.each do |group|
         next unless lockfile.groups[group.to_s]
-        dependencies += lockfile.groups[group.to_s]['dependencies']
+        dependencies += yield lockfile.groups[group.to_s]
 
         if with_locals
           locals = lockfile.groups[group.to_s]['locals']

--- a/lib/lock_jar/runtime/list.rb
+++ b/lib/lock_jar/runtime/list.rb
@@ -38,7 +38,7 @@ module LockJar
 
         # local_paths and !resolve are mutualally exclusive
         if opts[:local_paths] && opts[:resolve] != false
-          # remove local_paths opt soresolver is not reset
+          # remove local_paths opt so resolver is not reset
           resolver(opts.reject { |k| k == :local_paths }).to_local_paths(dependencies)
 
         else

--- a/lib/lock_jar/runtime/load.rb
+++ b/lib/lock_jar/runtime/load.rb
@@ -17,12 +17,11 @@ module LockJar
           if lockfile_or_path.is_a? LockJar::Domain::Lockfile
             lockfile = lockfile_or_path
 
-          # check if lockfile path is already loaded
-          elsif LockJar::Registry.instance.lockfile_registered?(lockfile_or_path)
-            return
-
-          # convert lockfile path to a Lockfile instance
           else
+            # check if lockfile path is already loaded
+            return if LockJar::Registry.instance.lockfile_registered?(lockfile_or_path)
+
+            # convert lockfile path to a Lockfile instance
             lockfile = LockJar::Domain::Lockfile.read(lockfile_or_path)
           end
 

--- a/lib/lock_jar/runtime/lock.rb
+++ b/lib/lock_jar/runtime/lock.rb
@@ -38,11 +38,11 @@ module LockJar
 
       def create_dsl!(jarfile_or_dsl, &blk)
         if jarfile_or_dsl
-          if jarfile_or_dsl.is_a? LockJar::Domain::Dsl
-            @jarfile = jarfile_or_dsl
-          else
-            @jarfile = LockJar::Domain::JarfileDsl.create(jarfile_or_dsl)
-          end
+          @jarfile = if jarfile_or_dsl.is_a? LockJar::Domain::Dsl
+                       jarfile_or_dsl
+                     else
+                       LockJar::Domain::JarfileDsl.create(jarfile_or_dsl)
+                     end
         end
 
         return @jarfile if blk.nil?
@@ -132,7 +132,7 @@ module LockJar
           # iterate each dependency in Pom to map transitive dependencies
           transitive = {}
           artifact.notations.each do |notation|
-            transitive.merge!(notation => resolver(opts).dependencies_graph[notation])
+            transitive[notation] = resolver(opts).dependencies_graph[notation]
           end
           artifact_data['transitive'] = transitive
 

--- a/lib/lock_jar/version.rb
+++ b/lib/lock_jar/version.rb
@@ -1,4 +1,4 @@
 # the version
 module LockJar
-  VERSION = '0.14.5'
+  VERSION = '0.14.5'.freeze
 end

--- a/spec/fixtures/Jarfile
+++ b/spec/fixtures/Jarfile
@@ -4,11 +4,11 @@ repository 'http://mirrors.ibiblio.org/pub/mirrors/maven2'
 jar "org.apache.mina:mina-core:2.0.4"
 local "spec/fixtures/naether-0.13.0.jar"
 pom 'spec/pom.xml'
-    
+
 group 'development' do
     jar 'com.typesafe:config:jar:0.5.0'
 end
 
 group 'test' do
-    jar 'junit:junit:jar:4.10'
+    jar 'org.testng:testng:jar:6.9.10'
 end

--- a/spec/lock_jar/domain/dsl_merger_spec.rb
+++ b/spec/lock_jar/domain/dsl_merger_spec.rb
@@ -15,7 +15,7 @@ describe LockJar::Domain::DslMerger do
       end
 
       group 'test' do
-        jar 'junit:junit:jar:4.10'
+        jar 'org.testng:testng:jar:6.9.10'
       end
     end
 

--- a/spec/lock_jar/domain/dsl_merger_spec.rb
+++ b/spec/lock_jar/domain/dsl_merger_spec.rb
@@ -39,11 +39,13 @@ describe LockJar::Domain::DslMerger do
 
     dsl = LockJar::Domain::DslMerger.new(block1, block2).merge
 
-    expect(dsl.artifacts['default']).to eq([
-      LockJar::Domain::Jar.new('org.apache.mina:mina-core:2.0.4'),
-      LockJar::Domain::Pom.new('spec/pom.xml', %w(runtime compile)),
-      LockJar::Domain::Jar.new('compile-jar')
-    ])
+    expect(dsl.artifacts['default']).to eq(
+      [
+        LockJar::Domain::Jar.new('org.apache.mina:mina-core:2.0.4'),
+        LockJar::Domain::Pom.new('spec/pom.xml', %w(runtime compile)),
+        LockJar::Domain::Jar.new('compile-jar')
+      ]
+    )
     dsl.remote_repositories.should eql(['http://repository.jboss.org/nexus/content/groups/public-jboss', 'http://new-repo'])
   end
 end

--- a/spec/lock_jar/domain/dsl_spec.rb
+++ b/spec/lock_jar/domain/dsl_spec.rb
@@ -15,7 +15,7 @@ describe LockJar::Domain::Dsl do
       expect(jarfile.artifacts['development'][0]).to eq LockJar::Domain::Jar.new('com.typesafe:config:jar:0.5.0')
       jarfile.artifacts['development'][1].should be_nil
 
-      expect(jarfile.artifacts['test'][0]).to eq LockJar::Domain::Jar.new('junit:junit:jar:4.10')
+      expect(jarfile.artifacts['test'][0]).to eq LockJar::Domain::Jar.new('org.testng:testng:jar:6.9.10')
       jarfile.artifacts['test'][1].should be_nil
 
       jarfile.remote_repositories.should eql(['http://mirrors.ibiblio.org/pub/mirrors/maven2'])
@@ -35,7 +35,7 @@ describe LockJar::Domain::Dsl do
         end
 
         group 'test' do
-          jar 'junit:junit:jar:4.10'
+          jar 'org.testng:testng:jar:6.9.10'
         end
       end
 
@@ -43,7 +43,7 @@ describe LockJar::Domain::Dsl do
       expect(block.artifacts).to eq(
         'default' => [LockJar::Domain::Jar.new('org.apache.mina:mina-core:2.0.4'), LockJar::Domain::Local.new('spec/fixtures/naether-0.13.0.jar'), LockJar::Domain::Pom.new('spec/pom.xml')],
         'pirate' => [LockJar::Domain::Jar.new('org.apache.tomcat:servlet-api:jar:6.0.35')],
-        'test' => [LockJar::Domain::Jar.new('junit:junit:jar:4.10')]
+        'test' => [LockJar::Domain::Jar.new('org.testng:testng:jar:6.9.10')]
       )
       block.remote_repositories.should eql(['http://repository.jboss.org/nexus/content/groups/public-jboss'])
     end

--- a/spec/lock_jar/resolver_spec.rb
+++ b/spec/lock_jar/resolver_spec.rb
@@ -18,8 +18,8 @@ describe LockJar::Resolver do
   end
 
   it 'should return local paths for notations' do
-    expect(@resolver.to_local_paths(['junit:junit:jar:4.10'])).to(
-      eql([File.expand_path("#{TEMP_DIR}/test-repo/junit/junit/4.10/junit-4.10.jar")])
+    expect(@resolver.to_local_paths(['org.testng:testng:jar:6.9.10'])).to(
+      eql([File.expand_path("#{TEMP_DIR}/test-repo/org/testng/testng/6.9.10/testng-6.9.10.jar")])
     )
   end
 end

--- a/spec/lock_jar/runtime_spec.rb
+++ b/spec/lock_jar/runtime_spec.rb
@@ -5,7 +5,7 @@ describe LockJar::Runtime do
   describe '#load' do
     it 'should set local repo' do
       LockJar::Runtime.instance.load(nil, [], resolve: true, local_repo: TEST_REPO) do
-        jar 'junit:junit:4.10'
+        jar 'org.testng:testng:jar:6.9.10'
       end
 
       LockJar::Runtime.instance.current_resolver.naether.local_repo_path.should eql TEST_REPO

--- a/spec/lock_jar_spec.rb
+++ b/spec/lock_jar_spec.rb
@@ -251,11 +251,13 @@ describe LockJar do
       LockJar.lock('spec/fixtures/Jarfile', download_artifacts: false, local_repo: "#{TEMP_DIR}/test-repo-install", lockfile: "#{TEMP_DIR}/Jarfile.lock")
 
       jars = LockJar.install("#{TEMP_DIR}/Jarfile.lock", ['default'], local_repo: "#{TEMP_DIR}/test-repo-install")
-      jars.should eql([
-        File.expand_path("#{repo_path}/com/google/guava/guava/14.0.1/guava-14.0.1.jar"),
-        File.expand_path("#{repo_path}/org/apache/mina/mina-core/2.0.4/mina-core-2.0.4.jar"),
-        File.expand_path("#{repo_path}/org/slf4j/slf4j-api/1.6.1/slf4j-api-1.6.1.jar")
-      ])
+      expect(jars).to eql(
+        [
+          File.expand_path("#{repo_path}/com/google/guava/guava/14.0.1/guava-14.0.1.jar"),
+          File.expand_path("#{repo_path}/org/apache/mina/mina-core/2.0.4/mina-core-2.0.4.jar"),
+          File.expand_path("#{repo_path}/org/slf4j/slf4j-api/1.6.1/slf4j-api-1.6.1.jar")
+        ]
+      )
     end
   end
 

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -14,9 +14,9 @@ ttp://maven.apache.org/maven-v4_0_0.xsd ">
   </repositories>
   <dependencies>
     <dependency>
-      <groupId>com.slackworks</groupId>
-      <artifactId>modelcitizen</artifactId>
-      <version>0.2.2</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
     </dependency>
     <dependency>
 			<groupId>org.jboss.unit</groupId>
@@ -24,11 +24,5 @@ ttp://maven.apache.org/maven-v4_0_0.xsd ">
 			<version>1.2.4</version>
       <scope>test</scope>
 		</dependency>
-	  <dependency>
-	      <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>4.8.2</version>
-          <scope>test</scope>
-	  </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
@r6p

Adding `resolve: false` to list is not a big deal, so calling `LockJar.list(resolve: false)` will return the artifacts used to create the dependencies. It will operate the same way your sample code from https://github.com/mguymon/lock_jar/issues/33. 

The one caution is, if there are non-jar references in the Gemfile, they will show up. For example if a [pom.xml is used](https://github.com/mguymon/lock_jar/blob/master/spec/fixtures/Jarfile#L6) it will be in the return a `'spec/pom.xml'`