### PR TITLE
Magic auth file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,4 @@ end
 group :development do
   gem 'pry'
   gem 'yard'
-  gem 'rubocop', '~> 0.36.0'
 end

--- a/lib/lock_jar.rb
+++ b/lib/lock_jar.rb
@@ -14,6 +14,7 @@
 # the License.
 
 require 'yaml'
+require 'lock_jar/config'
 require 'lock_jar/resolver'
 require 'lock_jar/runtime'
 require 'lock_jar/version'

--- a/lib/lock_jar/config.rb
+++ b/lib/lock_jar/config.rb
@@ -21,7 +21,7 @@ module LockJar
           .compact
           .find { |path| File.exist? path }
 
-        new(YAML.load(IO.read(config_path))) if config_path
+        new(YAML.load_file(config_path)) if config_path
       end
     end
 

--- a/lib/lock_jar/config.rb
+++ b/lib/lock_jar/config.rb
@@ -1,0 +1,40 @@
+require 'yaml'
+
+module LockJar
+  # Handle authentication for
+  class Config
+    CONFIG_ENV = 'LOCKJAR_CONFIG'.freeze
+    DEFAULT_FILENAME = '.lockjar'.freeze
+
+    attr_reader :repositories
+
+    class << self
+      def load_config_file
+        local_config_paths =
+          [Dir.pwd, Dir.home]
+          .map { |path| File.join(path, DEFAULT_FILENAME) }
+
+        config_path =
+          ([ENV[CONFIG_ENV]] + local_config_paths)
+          .compact
+          .find { |path| File.exist? path }
+
+        new(YAML.load(IO.read(config_path))) if config_path
+      end
+    end
+
+    #
+    # {
+    #   'repositories' => {
+    #     ':url' => {
+    #       'username' => ''
+    #       'password' => ''
+    #       'ssh_key' => ''
+    #     }
+    #   }
+    # }
+    def initialize(config)
+      @repositories = config['repositories'] || {}
+    end
+  end
+end

--- a/lib/lock_jar/config.rb
+++ b/lib/lock_jar/config.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 
 module LockJar
-  # Handle authentication for
+  # Global configuration for LockJar
   class Config
     CONFIG_ENV = 'LOCKJAR_CONFIG'.freeze
     DEFAULT_FILENAME = '.lockjar'.freeze
@@ -9,6 +9,8 @@ module LockJar
     attr_reader :repositories
 
     class << self
+      # Load .lockjar YAML config file from ENV['LOCKJAR_CONFIG'], current_dir, or
+      # home dir.
       def load_config_file
         local_config_paths =
           [Dir.pwd, Dir.home]
@@ -29,7 +31,6 @@ module LockJar
     #     ':url' => {
     #       'username' => ''
     #       'password' => ''
-    #       'ssh_key' => ''
     #     }
     #   }
     # }

--- a/lib/lock_jar/resolver.rb
+++ b/lib/lock_jar/resolver.rb
@@ -24,7 +24,7 @@ module LockJar
     attr_reader :config, :opts, :naether
 
     def initialize(config, opts = {})
-      @config = config
+      @config = config || LockJar::Config.new({})
       @opts = opts
       local_repo = opts[:local_repo] || Naether::Bootstrap.default_local_repo
 

--- a/lib/lock_jar/resolver.rb
+++ b/lib/lock_jar/resolver.rb
@@ -21,9 +21,10 @@ require 'fileutils'
 module LockJar
   #
   class Resolver
-    attr_reader :opts, :naether
+    attr_reader :config, :opts, :naether
 
-    def initialize(opts = {})
+    def initialize(config, opts = {})
+      @config = config
       @opts = opts
       local_repo = opts[:local_repo] || Naether::Bootstrap.default_local_repo
 
@@ -31,7 +32,6 @@ module LockJar
       Naether::Bootstrap.bootstrap_local_repo(local_repo, opts)
 
       # Bootstrapping naether will create an instance from downloaded jars.
-      # If jars exist locally already, create manually
       @naether = Naether.create
       @naether.local_repo_path = local_repo if local_repo
       @naether.clear_remote_repositories if opts[:offline]
@@ -46,7 +46,10 @@ module LockJar
     end
 
     def add_remote_repository(repo)
-      @naether.add_remote_repository(repo)
+      repo_config = config.repositories[repo] || {}
+      username = repo_config['username']
+      password = repo_config['password']
+      @naether.add_remote_repository(repo, username, password)
     end
 
     def resolve(dependencies, download_artifacts = true)

--- a/lib/lock_jar/runtime.rb
+++ b/lib/lock_jar/runtime.rb
@@ -15,6 +15,7 @@
 
 require 'yaml'
 require 'singleton'
+require 'lock_jar/config'
 require 'lock_jar/resolver'
 require 'lock_jar/registry'
 require 'lock_jar/domain/dsl'
@@ -33,9 +34,10 @@ module LockJar
     include List
     include Install
 
-    attr_reader :current_resolver
+    attr_reader :current_resolver, :config
 
     def initialize
+      @config = Config.load_config_file
       @current_resolver = nil
     end
 
@@ -59,7 +61,7 @@ module LockJar
       end
 
       if @current_resolver.nil? || opts != @current_resolver.opts
-        @current_resolver = LockJar::Resolver.new(opts)
+        @current_resolver = LockJar::Resolver.new(config, opts)
       end
 
       @current_resolver

--- a/lock_jar.gemspec
+++ b/lock_jar.gemspec
@@ -26,5 +26,6 @@ classpath'
   s.add_dependency('naether', ['~> 0.15.0'])
   s.add_dependency('thor', ['>= 0.18.1'])
   s.add_development_dependency('rspec', '~> 2.14.1')
+  s.add_development_dependency('rubocop', '~> 0.35.0')
   s.add_development_dependency('rake')
 end

--- a/spec/fixtures/lock_jar_config.yml
+++ b/spec/fixtures/lock_jar_config.yml
@@ -1,0 +1,4 @@
+repositories:
+  'https://some.fancy.doman/maven':
+    username: 'user1'
+    password: 'the_pass'

--- a/spec/lock_jar/config_spec.rb
+++ b/spec/lock_jar/config_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe LockJar::Config do
   describe '.load_config_file' do
     let(:test_config_file) { File.join('spec', 'fixtures', 'lock_jar_config.yml') }
+    let(:temp_config_file) { File.join(TEMP_DIR, described_class::DEFAULT_FILENAME) }
     let(:config) { described_class.load_config_file }
     let(:expected_repo_config) do
       {
@@ -13,9 +14,13 @@ describe LockJar::Config do
       }
     end
 
+    before do
+      FileUtils.cp(test_config_file, temp_config_file)
+    end
+
     context 'using current dir config' do
       before do
-        FileUtils.cp(test_config_file, File.join(Dir.pwd, described_class::DEFAULT_FILENAME))
+        allow(Dir).to receive(:pwd).and_return(TEMP_DIR)
       end
 
       it 'should have a repository config' do
@@ -24,9 +29,9 @@ describe LockJar::Config do
     end
 
     context 'using home dir config' do
+
       before do
-        FileUtils.rm(File.join(Dir.pwd, described_class::DEFAULT_FILENAME))
-        FileUtils.cp(test_config_file, File.join(Dir.home, described_class::DEFAULT_FILENAME))
+        allow(Dir).to receive(:home).and_return(TEMP_DIR)
       end
 
       it 'should have a repository config' do
@@ -36,7 +41,7 @@ describe LockJar::Config do
 
     context 'using ENV path to config' do
       before do
-        ENV[described_class::CONFIG_ENV] = File.join(Dir.pwd, described_class::DEFAULT_FILENAME)
+        ENV[described_class::CONFIG_ENV] = temp_config_file
       end
 
       it 'should have a repository config' do

--- a/spec/lock_jar/config_spec.rb
+++ b/spec/lock_jar/config_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe LockJar::Config do
+  describe '.load_config_file' do
+    let(:test_config_file) { File.join('spec', 'fixtures', 'lock_jar_config.yml') }
+    let(:config) { described_class.load_config_file }
+    let(:expected_repo_config) do
+      {
+        'https://some.fancy.doman/maven' => {
+          'username' => 'user1',
+          'password' => 'the_pass'
+        }
+      }
+    end
+
+    context 'using current dir config' do
+      before do
+        FileUtils.cp(test_config_file, File.join(Dir.pwd, described_class::DEFAULT_FILENAME))
+      end
+
+      it 'should have a repository config' do
+        expect(config.repositories).to eq(expected_repo_config)
+      end
+    end
+
+    context 'using home dir config' do
+      before do
+        FileUtils.rm(File.join(Dir.pwd, described_class::DEFAULT_FILENAME))
+        FileUtils.cp(test_config_file, File.join(Dir.home, described_class::DEFAULT_FILENAME))
+      end
+
+      it 'should have a repository config' do
+        expect(config.repositories).to eq(expected_repo_config)
+      end
+    end
+
+    context 'using ENV path to config' do
+      before do
+        ENV[described_class::CONFIG_ENV] = File.join(Dir.pwd, described_class::DEFAULT_FILENAME)
+      end
+
+      it 'should have a repository config' do
+        expect(config.repositories).to eq(expected_repo_config)
+      end
+    end
+  end
+end

--- a/spec/lock_jar/config_spec.rb
+++ b/spec/lock_jar/config_spec.rb
@@ -29,7 +29,6 @@ describe LockJar::Config do
     end
 
     context 'using home dir config' do
-
       before do
         allow(Dir).to receive(:home).and_return(TEMP_DIR)
       end

--- a/spec/lock_jar/resolver_spec.rb
+++ b/spec/lock_jar/resolver_spec.rb
@@ -41,7 +41,7 @@ describe LockJar::Resolver do
 
   describe '#add_remote_repository' do
     let(:remote_repos) do
-      Naether::Java.convert_to_ruby_array(subject.naether.remote_repositories).map do |repo|
+      subject.naether.remote_repositories.map do |repo|
         {
           url: repo.url
         }.tap do |hash|

--- a/spec/lock_jar/resolver_spec.rb
+++ b/spec/lock_jar/resolver_spec.rb
@@ -4,12 +4,26 @@ require 'fileutils'
 require 'naether'
 
 describe LockJar::Resolver do
-  before(:each) do
+  subject { described_class.new(config, local_repo: "#{TEMP_DIR}/test-repo") }
+
+  before do
     FileUtils.mkdir_p("#{TEMP_DIR}/test-repo")
-    @resolver = LockJar::Resolver.new(local_repo: "#{TEMP_DIR}/test-repo")
+  end
+
+  let(:config) do
+    LockJar::Config.new(
+      'repositories' => {
+        'https://test/repo' => {
+          'username' => 'user1',
+          'password' => 'pass1'
+        }
+      }
+    )
   end
 
   it 'should bootstrap naether' do
+    subject
+
     deps = Naether::Bootstrap.check_local_repo_for_deps("#{TEMP_DIR}/test-repo")
     deps[:missing].should eql([])
     deps[:exists].each do |dep|
@@ -17,9 +31,39 @@ describe LockJar::Resolver do
     end
   end
 
-  it 'should return local paths for notations' do
-    expect(@resolver.to_local_paths(['org.testng:testng:jar:6.9.10'])).to(
-      eql([File.expand_path("#{TEMP_DIR}/test-repo/org/testng/testng/6.9.10/testng-6.9.10.jar")])
-    )
+  describe '#to_local_paths' do
+    it 'should return local paths for notations' do
+      expect(subject.to_local_paths(['org.testng:testng:jar:6.9.10'])).to(
+        eql([File.expand_path("#{TEMP_DIR}/test-repo/org/testng/testng/6.9.10/testng-6.9.10.jar")])
+      )
+    end
+  end
+
+  describe '#add_remote_repository' do
+    let(:remote_repos) do
+      Naether::Java.convert_to_ruby_array(subject.naether.remote_repositories).map do |repo|
+        {
+          url: repo.url
+        }.tap do |hash|
+          if repo.authentication
+            hash[:username] = repo.authentication.username
+            hash[:password] = repo.authentication.password
+          end
+        end
+      end
+    end
+
+    let(:expected_remote_repos) do
+      [
+        { url: 'http://repo1.maven.org/maven2/' },
+        { url: 'https://test/repo', username: 'user1', password: 'pass1' }
+      ]
+    end
+
+    it 'should use repo config for auth' do
+      subject.add_remote_repository('https://test/repo')
+
+      expect(remote_repos).to eq(expected_remote_repos)
+    end
   end
 end


### PR DESCRIPTION
@r6p

Fix for https://github.com/mguymon/lock_jar/issues/36 by adding support for `.lockjar` config. Looks for ENV defined path, current dir, and home dir for the file, in that order of precedence. The config format is yaml, and follows:

```
repositories:
  'https://some.fancy.doman/maven':
    username: 'user1'
    password: 'the_pass'
```

Which will automatically get used if the repository is added in the lockfile.
